### PR TITLE
Fix text overflow, duplicate spaces and disallow modifying input after submission

### DIFF
--- a/classifiedwordcount.html
+++ b/classifiedwordcount.html
@@ -78,7 +78,7 @@
     <div class="section">
         <p class="explanation">To use this, first paste the minutes in the text box then click "Process".</p>
         <textarea id="inputminutes" rows="10" placeholder="Minutes go here"></textarea>
-        <button onclick="prepareMinutesFromTextArea();">Process</button>
+        <button onclick="prepareMinutesFromTextArea(); this.disabled = true">Process</button>
         <p class="explanation">Alternatively, read minutes from a plain text file: <input class="full" id="inputfile" type="file" onchange="readMinutesFromFile()"/></p>
     </div>
     <div class="section">

--- a/classifiedwordcount.html
+++ b/classifiedwordcount.html
@@ -241,10 +241,7 @@
         }
 
         function countWords(text){
-            if (text == ""){return 0;}
-            const matches = text.match(/ /g);
-            if (matches == null){return 1;}
-            else {return matches.length + 1;}
+            return text == "" ? 0 : text.split(" ").length
         }
 
         function addClass() {

--- a/classifiedwordcount.html
+++ b/classifiedwordcount.html
@@ -172,14 +172,14 @@
             addLine(line){
                 this.lines.add(line);
                 this.count += line.wordcount;
-                this.countbox.innerText = this.count;
+                this.countbox.innerText = `Word count: ${this.count}`;
             }
 
             removeLine(line){
                 var removalsuccess = this.lines.delete(line);
                 if (!removalsuccess){alert("Tried to remove set from nonexistent category. This shouldn't happen, please tell Kate.")}
                 this.count -= line.wordcount;
-                this.countbox.innerText = this.count;
+                this.countbox.innerText = `Word count: ${this.count}`;
             }
         }
 
@@ -240,7 +240,16 @@
             })
         }
 
+        function removeDuplicateSpaces(text){
+            // recursively remove duplicate spaces
+            while (text.includes("  ")){
+                text = text.replace("  ", " ")
+            }
+            return text
+        }
+
         function countWords(text){
+            text = removeDuplicateSpaces(text)
             return text == "" ? 0 : text.split(" ").length
         }
 

--- a/classifiedwordcount.html
+++ b/classifiedwordcount.html
@@ -42,6 +42,8 @@
         p {
             margin-block-start: 0.5em;
             margin-block-end: 1em;
+            overflow-y: auto;
+            overflow-wrap: break-word;
         }
 
         .explanation {


### PR DESCRIPTION
Text should (hopefully) not break out of explanation elements.

Multiple consecutive spaces are replaced with single spaces.

The increment/decrement in the addLine/removeLine class methods assumes that the number of words on a line stays consistent. This is potentially not the case if the user edits the textarea and clicks "Process" again. Ideally we would recalculate the number of words if the textarea is modified, but as a stopgap we can just prevent the user from clicking "Process" again.


